### PR TITLE
partial fix for #2

### DIFF
--- a/assets/javascripts/git_url_display.js
+++ b/assets/javascripts/git_url_display.js
@@ -2,9 +2,18 @@ var allGitUrlIds = ["git_url_ssh", "git_url_http", "git_url_git"]
 function updateGitUrl(el)
 {
 	guHttpBase = guHttpBase.replace(/\/$/, "")
+	if ( guGitServer.indexOf(':') != -1 ) {
+		guSshPort = guGitServer.slice(guGitServer.indexOf(':'))
+	} else {
+		guSshPort = ''
+	}
 
 	var urls=[]
-	urls["git_url_ssh"]  = [guGitUser + "@" + guGitServer + ":" + guSshURL, guUserIsCommitter]
+	if ( guSshPort == '' ) {
+		urls["git_url_ssh"]  = [guGitUser + "@" + guGitServer + ":" + guSshURL, guUserIsCommitter]
+	} else {
+		urls["git_url_ssh"]  = ["ssh://" + guGitUser + "@" + guGitServer + "/" + guSshURL, guUserIsCommitter]
+	}
 	urls["git_url_http"] = [guHttpProto + "://" + ( (!guProjectIsPublic) || guUserIsCommitter ? guUser + "@" : "") + guHttpBase + "/" + guHttpURL, guUserIsCommitter]
 	urls["git_url_git"]  = ["git://" + guGitServer + "/" + guSshURL, false]
 	var allGitUrlIds = ["git_url_ssh", "git_url_http", "git_url_git"]


### PR DESCRIPTION
Hi,

Sorry, but I couldn't find a way to attach commits to the issue I created,
so I decided to simply make a pull request.

This patch checks wether an alternate port is specified in the gitServer param and adjusts the clone url boxes accordingly.
Sadly I haven't yet found a way to do the same with the git instructions template for empty repos.
It's also most likely not the cleanest solutions, but it works.
Any thoughts?

Signed-off-by: Dave Simons dave@inuits.eu
