### PR TITLE
Fixes mostly related to initial migration

### DIFF
--- a/app/models/git_hosting_settings_observer.rb
+++ b/app/models/git_hosting_settings_observer.rb
@@ -1,7 +1,9 @@
 class GitHostingSettingsObserver < ActiveRecord::Observer
     observe :setting
 
-    @@old_valuehash = (Setting.plugin_redmine_git_hosting).clone
+    def init_old_value
+    	@@old_valuehash ||= (Setting.plugin_redmine_git_hosting).clone
+    end
 
     def reload_this_observer
 	observed_classes.each do |klass|
@@ -15,6 +17,8 @@ class GitHostingSettingsObserver < ActiveRecord::Observer
     # Thus, we can only silently refuse to perform bad changes and/or perform
     # slight corrections to badly formatted values.
     def before_save(object)
+    	init_old_value
+
 	# Only validate settings for our plugin
 	if object.name == "plugin_redmine_git_hosting"
 	    valuehash = object.value
@@ -174,6 +178,8 @@ class GitHostingSettingsObserver < ActiveRecord::Observer
     end
 
     def after_save(object)
+    	init_old_value
+    	
 	# Only perform after-actions on settings for our plugin
 	if object.name == "plugin_redmine_git_hosting"
 	    valuehash = object.value

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ def install_redmine_git_hosting_routes(map)
     # Note that 'http_server_subdir' is either empty (default case) or ends in '/'.
     begin
 	    prefix = Setting.plugin_redmine_git_hosting['httpServerSubdir']
-	rescue ActiveRecord::StatementInvalid
+	rescue
 		prefix = ''
 	end
     map.connect ":repo_path/*path",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,13 @@
 def install_redmine_git_hosting_routes(map)
     # URL for items of type httpServer/XXX.git.	 Some versions of rails has problems with multiple regex expressions, so avoid...
     # Note that 'http_server_subdir' is either empty (default case) or ends in '/'.
+    begin
+	    prefix = Setting.plugin_redmine_git_hosting['httpServerSubdir']
+	rescue ActiveRecord::StatementInvalid
+		prefix = ''
+	end
     map.connect ":repo_path/*path",
-    :prefix => Setting.plugin_redmine_git_hosting['httpServerSubdir'], :repo_path => /([^\/]+\/)*?[^\/]+\.git/, :controller => 'git_http'
+    :prefix => prefix, :repo_path => /([^\/]+\/)*?[^\/]+\.git/, :controller => 'git_http'
 
     # Handle the public keys plugin to my/account.
     map.resources :public_keys, :controller => 'gitolite_public_keys', :path_prefix => 'my'

--- a/init.rb
+++ b/init.rb
@@ -90,7 +90,7 @@ Redmine::Scm::Base.all.unshift("Git").uniq!
 
 # initialize observer
 config.after_initialize do
-    if config.action_controller.perform_caching
+    if config.action_controller.perform_caching && !(File.basename($0) == "rake" && ARGV.include?("db:migrate"))
 	ActiveRecord::Base.observers = ActiveRecord::Base.observers << GitHostingObserver
 	ActiveRecord::Base.observers = ActiveRecord::Base.observers << GitHostingSettingsObserver
 

--- a/lib/cached_shell_redirector.rb
+++ b/lib/cached_shell_redirector.rb
@@ -104,7 +104,7 @@ class CachedShellRedirector
     # Ruby 1.8 define_method doesn't work with blocks.
     def method_missing(my_method, *args, &block)
 	# Only handle IO methods!
-	if IO.instance_methods.index(my_method.to_sym).nil?
+	unless IO.instance_methods.map { |m| m.to_s }.include? my_method.to_s
 	    return super(my_method, *args, &block)
 	end
 

--- a/lib/cached_shell_redirector.rb
+++ b/lib/cached_shell_redirector.rb
@@ -104,7 +104,7 @@ class CachedShellRedirector
     # Ruby 1.8 define_method doesn't work with blocks.
     def method_missing(my_method, *args, &block)
 	# Only handle IO methods!
-	if IO.instance_methods.index(my_method.to_s).nil?
+	if IO.instance_methods.index(my_method.to_sym).nil?
 	    return super(my_method, *args, &block)
 	end
 

--- a/lib/cached_shell_redirector.rb
+++ b/lib/cached_shell_redirector.rb
@@ -104,7 +104,7 @@ class CachedShellRedirector
     # Ruby 1.8 define_method doesn't work with blocks.
     def method_missing(my_method, *args, &block)
 	# Only handle IO methods!
-	unless IO.instance_methods.map { |m| m.to_s }.include? my_method.to_s
+	unless IO.instance_methods.map(&:to_sym).include? my_method.to_sym
 	    return super(my_method, *args, &block)
 	end
 

--- a/lib/git_hosting/patches/repositories_controller_patch.rb
+++ b/lib/git_hosting/patches/repositories_controller_patch.rb
@@ -24,8 +24,8 @@ module GitHosting
 		GitHostingObserver.set_update_active(false);
 		params[:repository] ||= {}
 
-		if params[:repository_scm] == "Git"
-		    params[:repository][:url] = GitHosting.repository_path(@project)
+		if params[:repository_scm] == "Git" && @project.repository
+		    params[:repository][:url] = GitHosting.repository_path(@project.repository)
 		end
 
 		if params[:repository_scm] == "Git" || @project.repository.is_a?(Repository::Git)


### PR DESCRIPTION
The majority of these changes are there to handle the initial `db:migrate` when the plugin is already installed. The observers are disabled when migrating and neither the routes nor the settings observer assume any database tables exist. Also, two presumed typos are fixed.
