### PR TITLE
Fix an error that occurs while uninstalling from DB

### DIFF
--- a/db/migrate/2011072600000_extend_changesets_notified_cia.rb
+++ b/db/migrate/2011072600000_extend_changesets_notified_cia.rb
@@ -5,6 +5,10 @@ class ExtendChangesetsNotifiedCia < ActiveRecord::Migration
 
     def self.down
 	# Deal with fact that one of next migrations doesn't restore :notified_cia
-	remove_column(:changesets, :notified_cia) rescue nil
+	remove_column :changesets, :notified_cia if self.column_exists?(:changesets, :notified_cia)
+    end
+
+    def self.column_exists?(table_name, column_name)
+	columns(table_name).any?{ |c| c.name == column_name.to_s }
     end
 end


### PR DESCRIPTION
2011072600000_extend_changesets_notified_cia.rb tries to delete
notified_cia column in changesets table, but
2011081700000_move_notified_cia_to_git_cia_notifications.rb deletes
notified_cia column before it does, so an error occurs.

A solution is to let 2011072600000_extend_changesets_notified_cia.rb
remove notified_cia column only if the column exists.
